### PR TITLE
Implemented Bossbar colors

### DIFF
--- a/src/BossEventPacket.php
+++ b/src/BossEventPacket.php
@@ -70,12 +70,12 @@ class BossEventPacket extends DataPacket implements ClientboundPacket, Serverbou
 		return $result;
 	}
 
-	public static function show(int $bossActorUniqueId, string $title, float $healthPercent, int $unknownShort = 0) : self{
+	public static function show(int $bossActorUniqueId, string $title, float $healthPercent, int $unknownShort = 0, int $color = self::COLOR_PINK) : self{
 		$result = self::base($bossActorUniqueId, self::TYPE_SHOW);
 		$result->title = $title;
 		$result->healthPercent = $healthPercent;
 		$result->unknownShort = $unknownShort;
-		$result->color = 0;
+		$result->color = $color;
 		$result->overlay = 0;
 		return $result;
 	}

--- a/src/BossEventPacket.php
+++ b/src/BossEventPacket.php
@@ -67,7 +67,7 @@ class BossEventPacket extends DataPacket implements ClientboundPacket, Serverbou
 		$result->title = $title;
 		$result->healthPercent = $healthPercent;
 		$result->unknownShort = $unknownShort;
-		$result->color = 0; //hardcoded due to being useless
+		$result->color = 0;
 		$result->overlay = 0;
 		return $result;
 	}

--- a/src/BossEventPacket.php
+++ b/src/BossEventPacket.php
@@ -45,6 +45,14 @@ class BossEventPacket extends DataPacket implements ClientboundPacket, Serverbou
 	/* S2C: Not implemented :( Intended to alter bar appearance, but these currently produce no effect on client-side whatsoever. */
 	public const TYPE_TEXTURE = 7;
 
+	public const COLOR_PINK = 0;
+	public const COLOR_BLUE = 1;
+	public const COLOR_RED = 2;
+	public const COLOR_GREEN = 3;
+	public const COLOR_YELLOW = 4;
+	public const COLOR_PURPLE = 5;
+	public const COLOR_WHITE = 6;
+
 	public int $bossActorUniqueId;
 	public int $eventType;
 

--- a/src/BossEventPacket.php
+++ b/src/BossEventPacket.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\network\mcpe\protocol;
 
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
+use pocketmine\network\mcpe\protocol\types\BossBarColor;
 
 class BossEventPacket extends DataPacket implements ClientboundPacket, ServerboundPacket{
 	public const NETWORK_ID = ProtocolInfo::BOSS_EVENT_PACKET;
@@ -45,14 +46,6 @@ class BossEventPacket extends DataPacket implements ClientboundPacket, Serverbou
 	/* S2C: Not implemented :( Intended to alter bar appearance, but these currently produce no effect on client-side whatsoever. */
 	public const TYPE_TEXTURE = 7;
 
-	public const COLOR_PINK = 0;
-	public const COLOR_BLUE = 1;
-	public const COLOR_RED = 2;
-	public const COLOR_GREEN = 3;
-	public const COLOR_YELLOW = 4;
-	public const COLOR_PURPLE = 5;
-	public const COLOR_WHITE = 6;
-
 	public int $bossActorUniqueId;
 	public int $eventType;
 
@@ -70,7 +63,7 @@ class BossEventPacket extends DataPacket implements ClientboundPacket, Serverbou
 		return $result;
 	}
 
-	public static function show(int $bossActorUniqueId, string $title, float $healthPercent, int $unknownShort = 0, int $color = self::COLOR_PINK) : self{
+	public static function show(int $bossActorUniqueId, string $title, float $healthPercent, int $unknownShort = 0, int $color = BossBarColor::PURPLE) : self{
 		$result = self::base($bossActorUniqueId, self::TYPE_SHOW);
 		$result->title = $title;
 		$result->healthPercent = $healthPercent;

--- a/src/types/BossBarColor.php
+++ b/src/types/BossBarColor.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+class BossBarColor{
+
+	public const PINK = 0;
+	public const BLUE = 1;
+	public const RED = 2;
+	public const GREEN = 3;
+	public const YELLOW = 4;
+	public const PURPLE = 5;
+	public const WHITE = 6;
+
+}

--- a/src/types/BossBarColor.php
+++ b/src/types/BossBarColor.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
 namespace pocketmine\network\mcpe\protocol\types;
 
 class BossBarColor{


### PR DESCRIPTION
I noticed Bossbar colors were implemented in I'm guessing the 1.18 update.
This will PR will add this feature.

Pink = 0
![image](https://user-images.githubusercontent.com/34657342/145823066-5032c21b-822d-4cc8-a2d4-2880c565a13b.png)

Blue = 1
![image](https://user-images.githubusercontent.com/34657342/145823142-15506cad-1e9a-419f-8ce0-6bf7d0ec7e92.png)

Red = 2
![image](https://user-images.githubusercontent.com/34657342/145823208-c046faf0-22b5-40aa-b5c3-74107f4b0fd3.png)

Green = 3
![image](https://user-images.githubusercontent.com/34657342/145823334-7af5dd3c-c898-4c6d-9d28-35357d44a7f8.png)

Yellow = 4
![image](https://user-images.githubusercontent.com/34657342/145823385-f43e6c1b-6138-4b4c-a7b2-9ea7237394a2.png)

Purple = 5
![image](https://user-images.githubusercontent.com/34657342/145823436-9c4a93b3-7a7d-4785-84b7-83151e742b80.png)

White = 6
![image](https://user-images.githubusercontent.com/34657342/145823485-9eb2bc6f-55b4-4ba1-938e-0a62fd98af5b.png)
