### PR TITLE
Fix MovementType read/write using signed varints

### DIFF
--- a/src/types/PlayerMovementSettings.php
+++ b/src/types/PlayerMovementSettings.php
@@ -36,14 +36,14 @@ final class PlayerMovementSettings{
 	public function isServerAuthoritativeBlockBreaking() : bool{ return $this->serverAuthoritativeBlockBreaking; }
 
 	public static function read(PacketSerializer $in) : self{
-		$movementType = $in->getVarInt();
+		$movementType = $in->getUnsignedVarInt();
 		$rewindHistorySize = $in->getVarInt();
 		$serverAuthBlockBreaking = $in->getBool();
 		return new self($movementType, $rewindHistorySize, $serverAuthBlockBreaking);
 	}
 
 	public function write(PacketSerializer $out) : void{
-		$out->putVarInt($this->movementType);
+		$out->putUnsignedVarInt($this->movementType);
 		$out->putVarInt($this->rewindHistorySize);
 		$out->putBool($this->serverAuthoritativeBlockBreaking);
 	}


### PR DESCRIPTION
The MovementType is supposed to be an UnsignedVarInt, not a signed one.

Example to be seen here: https://github.com/CloudburstMC/Protocol/blob/35bdab91b9e1df3959d40d90512a827adeacec30/bedrock/bedrock-v428/src/main/java/com/nukkitx/protocol/bedrock/v428/serializer/StartGameSerializer_v428.java#L101
