### PR TITLE
Fix #109 (Add color parameter to `BossEventPacket::unknown6`)

### DIFF
--- a/src/BossEventPacket.php
+++ b/src/BossEventPacket.php
@@ -94,10 +94,10 @@ class BossEventPacket extends DataPacket implements ClientboundPacket, Serverbou
 		return $result;
 	}
 
-	public static function unknown6(int $bossActorUniqueId, int $unknownShort) : self{
+	public static function unknown6(int $bossActorUniqueId, int $unknownShort, int $color = BossBarColor::PURPLE) : self{
 		$result = self::base($bossActorUniqueId, self::TYPE_UNKNOWN_6);
 		$result->unknownShort = $unknownShort;
-		$result->color = 0; //hardcoded due to being useless
+		$result->color = $color;
 		$result->overlay = 0;
 		return $result;
 	}


### PR DESCRIPTION
As mentioned in #109, the $color field of the `BossEventPacket::unknown6` method is hardcoded. This PR aims at resolving this.