### PR TITLE
Implement death stuff metadata properties

### DIFF
--- a/src/types/entity/EntityMetadataProperties.php
+++ b/src/types/entity/EntityMetadataProperties.php
@@ -139,4 +139,8 @@ final class EntityMetadataProperties{
 	public const AMBIENT_SOUND_INTERVAL_MIN = 108; //float
 	public const AMBIENT_SOUND_INTERVAL_RANGE = 109; //float
 	public const AMBIENT_SOUND_EVENT = 110; //string
+
+	public const PLAYER_DEATH_POSITION = 128; //blockpos
+	public const PLAYER_DEATH_DIMENSION = 129; //int
+	public const PLAYER_HAS_DIED = 130; //byte
 }


### PR DESCRIPTION
These are necessary for the implementation of the recovery compass.

Obtained from dragonfly/gophertunnel and play-tested.