### PR TITLE
Update constants for player death info metadata properties

### DIFF
--- a/src/types/entity/EntityMetadataProperties.php
+++ b/src/types/entity/EntityMetadataProperties.php
@@ -140,7 +140,7 @@ final class EntityMetadataProperties{
 	public const AMBIENT_SOUND_INTERVAL_RANGE = 109; //float
 	public const AMBIENT_SOUND_EVENT = 110; //string
 
-	public const PLAYER_DEATH_POSITION = 128; //blockpos
-	public const PLAYER_DEATH_DIMENSION = 129; //int
-	public const PLAYER_HAS_DIED = 130; //byte
+	public const PLAYER_DEATH_POSITION = 127; //blockpos
+	public const PLAYER_DEATH_DIMENSION = 128; //int
+	public const PLAYER_HAS_DIED = 129; //byte
 }


### PR DESCRIPTION
Apparently mojang changed it in protocol version 557