### PR TITLE
PlayerActionPacket: Fix PlayerActionPacket cannot being sent to a player

### DIFF
--- a/src/PlayerActionPacket.php
+++ b/src/PlayerActionPacket.php
@@ -18,7 +18,7 @@ use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\network\mcpe\protocol\types\BlockPosition;
 use pocketmine\network\mcpe\protocol\types\PlayerAction;
 
-class PlayerActionPacket extends DataPacket implements ServerboundPacket{
+class PlayerActionPacket extends DataPacket implements ClientboundPacket, ServerboundPacket{
 	public const NETWORK_ID = ProtocolInfo::PLAYER_ACTION_PACKET;
 
 	public int $actorRuntimeId;


### PR DESCRIPTION
`PlayerAction::DIMENSION_CHANGE_ACK` need to be sent when changing player dimension.