### PR TITLE
Typo in StructureEditorData.php

### DIFF
--- a/src/serializer/PacketSerializer.php
+++ b/src/serializer/PacketSerializer.php
@@ -765,7 +765,7 @@ class PacketSerializer extends BinaryStream{
 
 		$result->structureBlockType = $this->getVarInt();
 		$result->structureSettings = $this->getStructureSettings();
-		$result->structureRedstoneSaveMove = $this->getVarInt();
+		$result->structureRedstoneSaveMode = $this->getVarInt();
 
 		return $result;
 	}
@@ -779,7 +779,7 @@ class PacketSerializer extends BinaryStream{
 
 		$this->putVarInt($structureEditorData->structureBlockType);
 		$this->putStructureSettings($structureEditorData->structureSettings);
-		$this->putVarInt($structureEditorData->structureRedstoneSaveMove);
+		$this->putVarInt($structureEditorData->structureRedstoneSaveMode);
 	}
 
 	public function getNbtRoot() : TreeRoot{

--- a/src/types/StructureEditorData.php
+++ b/src/types/StructureEditorData.php
@@ -28,5 +28,5 @@ class StructureEditorData{
 	public bool $showBoundingBox;
 	public int $structureBlockType;
 	public StructureSettings $structureSettings;
-	public int $structureRedstoneSaveMove;
+	public int $structureRedstoneSaveMode;
 }


### PR DESCRIPTION
In `StructureEditorData.php`, there is a field called `structureRedstoneSaveMove`.
Considering there is an NBT tag named `redstoneSaveMode` for the StructureBlock, it is likely that this is a typo.

**This is a breaking change**