### PR TITLE
Update field order and fix enum values in CorrectPlayerMovePredictionPacket

### DIFF
--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -59,7 +59,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 
 	public function getPredictionType() : int{ return $this->predictionType; }
 
-    public function getVehicleRotation() : ?Vector2{ return $this->vehicleRotation; }
+	public function getVehicleRotation() : ?Vector2{ return $this->vehicleRotation; }
 
 	protected function decodePayload(PacketSerializer $in) : void{
 		$this->predictionType = $in->getByte();
@@ -76,7 +76,11 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$out->putByte($this->predictionType);
 		$out->putVector3($this->position);
 		$out->putVector3($this->delta);
-		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE && $this->vehicleRotation != null) {
+		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
+			if($this->vehicleRotation == null) { // this should never be the case
+				throw new \InvalidArgumentException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
+			}
+
 			$out->putFloat($this->vehicleRotation->getX());
 			$out->putFloat($this->vehicleRotation->getY());
 		}

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -14,31 +14,38 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol;
 
+use pocketmine\math\Vector2;
 use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 
 class CorrectPlayerMovePredictionPacket extends DataPacket implements ClientboundPacket{
 	public const NETWORK_ID = ProtocolInfo::CORRECT_PLAYER_MOVE_PREDICTION_PACKET;
 
-	public const PREDICTION_TYPE_VEHICLE = 0;
-	public const PREDICTION_TYPE_PLAYER = 1;
+	public const PREDICTION_TYPE_PLAYER = 0;
+	public const PREDICTION_TYPE_VEHICLE = 1;
 
 	private Vector3 $position;
 	private Vector3 $delta;
 	private bool $onGround;
 	private int $tick;
 	private int $predictionType;
+	private ?Vector2 $rotation;
 
 	/**
 	 * @generate-create-func
 	 */
-	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType) : self{
+	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $rotation) : self{
 		$result = new self;
 		$result->position = $position;
 		$result->delta = $delta;
 		$result->onGround = $onGround;
 		$result->tick = $tick;
 		$result->predictionType = $predictionType;
+
+		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $rotation == null) {
+			throw new \InvalidArgumentException("CorrectPlayerMovePredictionPackets with type VEHICLE require a rotation to be provided");
+		}
+
 		return $result;
 	}
 
@@ -52,20 +59,29 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 
 	public function getPredictionType() : int{ return $this->predictionType; }
 
+    public function getRotation() : ?Vector2{ return $this->rotation; }
+
 	protected function decodePayload(PacketSerializer $in) : void{
+		$this->predictionType = $in->getByte();
 		$this->position = $in->getVector3();
 		$this->delta = $in->getVector3();
+		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
+			$this->rotation = new Vector2($in->getFloat(), $in->getFloat());
+		}
 		$this->onGround = $in->getBool();
 		$this->tick = $in->getUnsignedVarLong();
-		$this->predictionType = $in->getByte();
 	}
 
 	protected function encodePayload(PacketSerializer $out) : void{
+		$out->putByte($this->predictionType);
 		$out->putVector3($this->position);
 		$out->putVector3($this->delta);
+		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
+			$out->putFloat($this->rotation->getX());
+			$out->putFloat($this->rotation->getY());
+		}
 		$out->putBool($this->onGround);
 		$out->putUnsignedVarLong($this->tick);
-		$out->putByte($this->predictionType);
 	}
 
 	public function handle(PacketHandlerInterface $handler) : bool{

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -63,7 +63,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$this->predictionType = $in->getByte();
 		$this->position = $in->getVector3();
 		$this->delta = $in->getVector3();
-		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
+		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE){
 			$this->vehicleRotation = new Vector2($in->getFloat(), $in->getFloat());
 		}
 		$this->onGround = $in->getBool();

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -31,20 +31,26 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 	private int $predictionType;
 	private ?Vector2 $vehicleRotation;
 
-	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation) : self{
+	/**
+	 * @generate-create-func
+	 */
+	private static function internalCreate(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation) : self{
 		$result = new self;
 		$result->position = $position;
 		$result->delta = $delta;
 		$result->onGround = $onGround;
 		$result->tick = $tick;
 		$result->predictionType = $predictionType;
+		$result->vehicleRotation = $vehicleRotation;
+		return $result;
+	}
 
+	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation) : self{
 		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $vehicleRotation === null){
 			throw new \LogicException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
 		}
 
-		$result->vehicleRotation = $vehicleRotation;
-		return $result;
+		return self::internalCreate($position, $delta, $onGround, $tick, $predictionType, $vehicleRotation);
 	}
 
 	public function getPosition() : Vector3{ return $this->position; }

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -29,12 +29,12 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 	private bool $onGround;
 	private int $tick;
 	private int $predictionType;
-	private ?Vector2 $rotation;
+	private ?Vector2 $vehicleRotation;
 
 	/**
 	 * @generate-create-func
 	 */
-	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $rotation) : self{
+	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation) : self{
 		$result = new self;
 		$result->position = $position;
 		$result->delta = $delta;
@@ -42,8 +42,8 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$result->tick = $tick;
 		$result->predictionType = $predictionType;
 
-		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $rotation == null) {
-			throw new \InvalidArgumentException("CorrectPlayerMovePredictionPackets with type VEHICLE require a rotation to be provided");
+		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $vehicleRotation == null) {
+			throw new \InvalidArgumentException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
 		}
 
 		return $result;
@@ -59,14 +59,14 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 
 	public function getPredictionType() : int{ return $this->predictionType; }
 
-    public function getRotation() : ?Vector2{ return $this->rotation; }
+    public function getVehicleRotation() : ?Vector2{ return $this->vehicleRotation; }
 
 	protected function decodePayload(PacketSerializer $in) : void{
 		$this->predictionType = $in->getByte();
 		$this->position = $in->getVector3();
 		$this->delta = $in->getVector3();
 		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
-			$this->rotation = new Vector2($in->getFloat(), $in->getFloat());
+			$this->vehicleRotation = new Vector2($in->getFloat(), $in->getFloat());
 		}
 		$this->onGround = $in->getBool();
 		$this->tick = $in->getUnsignedVarLong();
@@ -77,8 +77,8 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$out->putVector3($this->position);
 		$out->putVector3($this->delta);
 		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
-			$out->putFloat($this->rotation->getX());
-			$out->putFloat($this->rotation->getY());
+			$out->putFloat($this->vehicleRotation->getX());
+			$out->putFloat($this->vehicleRotation->getY());
 		}
 		$out->putBool($this->onGround);
 		$out->putUnsignedVarLong($this->tick);

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -76,7 +76,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$out->putByte($this->predictionType);
 		$out->putVector3($this->position);
 		$out->putVector3($this->delta);
-		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
+		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE && $this->vehicleRotation != null) {
 			$out->putFloat($this->vehicleRotation->getX());
 			$out->putFloat($this->vehicleRotation->getY());
 		}

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -39,7 +39,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$result->tick = $tick;
 		$result->predictionType = $predictionType;
 
-		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $vehicleRotation == null) {
+		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $vehicleRotation === null){
 			throw new \LogicException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
 		}
 

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -75,7 +75,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$out->putVector3($this->delta);
 		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
 			if($this->vehicleRotation == null) { // this should never be the case
-				throw new \InvalidArgumentException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
+				throw new \LogicException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
 			}
 
 			$out->putFloat($this->vehicleRotation->getX());

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -75,7 +75,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$out->putVector3($this->position);
 		$out->putVector3($this->delta);
 		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE){
-			if($this->vehicleRotation == null) { // this should never be the case
+			if($this->vehicleRotation === null){ // this should never be the case
 				throw new \LogicException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
 			}
 

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -41,10 +41,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$result->onGround = $onGround;
 		$result->tick = $tick;
 		$result->predictionType = $predictionType;
-
-		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $vehicleRotation == null) {
-			throw new \InvalidArgumentException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
-		}
+		$result->vehicleRotation = $vehicleRotation;
 
 		return $result;
 	}

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -42,7 +42,6 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$result->tick = $tick;
 		$result->predictionType = $predictionType;
 		$result->vehicleRotation = $vehicleRotation;
-
 		return $result;
 	}
 

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -31,9 +31,6 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 	private int $predictionType;
 	private ?Vector2 $vehicleRotation;
 
-	/**
-	 * @generate-create-func
-	 */
 	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation) : self{
 		$result = new self;
 		$result->position = $position;
@@ -41,6 +38,11 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$result->onGround = $onGround;
 		$result->tick = $tick;
 		$result->predictionType = $predictionType;
+
+		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $vehicleRotation == null) {
+			throw new \LogicException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
+		}
+
 		$result->vehicleRotation = $vehicleRotation;
 		return $result;
 	}

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -74,7 +74,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$out->putByte($this->predictionType);
 		$out->putVector3($this->position);
 		$out->putVector3($this->delta);
-		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE) {
+		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE){
 			if($this->vehicleRotation == null) { // this should never be the case
 				throw new \LogicException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
 			}


### PR DESCRIPTION
The field order in the CorrectPlayerMovePredictionPacket is wrong, the `predictionType` was moved to the front of the buffer and there was an additional field of type `Vector2` for the `VehicleRotation` added.

Additionally, the `predictionType` Enum is corrected to be the other way around.