### PR TITLE
Improvement on 1.21.2 support

### DIFF
--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -35,7 +35,15 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 	/**
 	 * @generate-create-func
 	 */
-	private static function internalCreate(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation, ?float $vehicleAngularVelocity) : self{
+	private static function internalCreate(
+		Vector3 $position,
+		Vector3 $delta,
+		bool $onGround,
+		int $tick,
+		int $predictionType,
+		?Vector2 $vehicleRotation,
+		?float $vehicleAngularVelocity,
+	) : self{
 		$result = new self;
 		$result->position = $position;
 		$result->delta = $delta;

--- a/src/CorrectPlayerMovePredictionPacket.php
+++ b/src/CorrectPlayerMovePredictionPacket.php
@@ -30,11 +30,12 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 	private int $tick;
 	private int $predictionType;
 	private ?Vector2 $vehicleRotation;
+	private ?float $vehicleAngularVelocity;
 
 	/**
 	 * @generate-create-func
 	 */
-	private static function internalCreate(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation) : self{
+	private static function internalCreate(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation, ?float $vehicleAngularVelocity) : self{
 		$result = new self;
 		$result->position = $position;
 		$result->delta = $delta;
@@ -42,15 +43,16 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 		$result->tick = $tick;
 		$result->predictionType = $predictionType;
 		$result->vehicleRotation = $vehicleRotation;
+		$result->vehicleAngularVelocity = $vehicleAngularVelocity;
 		return $result;
 	}
 
-	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation) : self{
+	public static function create(Vector3 $position, Vector3 $delta, bool $onGround, int $tick, int $predictionType, ?Vector2 $vehicleRotation, ?float $vehicleAngularVelocity) : self{
 		if($predictionType === self::PREDICTION_TYPE_VEHICLE && $vehicleRotation === null){
 			throw new \LogicException("CorrectPlayerMovePredictionPackets with type VEHICLE require a vehicleRotation to be provided");
 		}
 
-		return self::internalCreate($position, $delta, $onGround, $tick, $predictionType, $vehicleRotation);
+		return self::internalCreate($position, $delta, $onGround, $tick, $predictionType, $vehicleRotation, $vehicleAngularVelocity);
 	}
 
 	public function getPosition() : Vector3{ return $this->position; }
@@ -65,12 +67,15 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 
 	public function getVehicleRotation() : ?Vector2{ return $this->vehicleRotation; }
 
+	public function getVehicleAngularVelocity() : ?float{ return $this->vehicleAngularVelocity; }
+
 	protected function decodePayload(PacketSerializer $in) : void{
 		$this->predictionType = $in->getByte();
 		$this->position = $in->getVector3();
 		$this->delta = $in->getVector3();
 		if($this->predictionType === self::PREDICTION_TYPE_VEHICLE){
 			$this->vehicleRotation = new Vector2($in->getFloat(), $in->getFloat());
+			$this->vehicleAngularVelocity = $in->readOptional($in->getFloat(...));
 		}
 		$this->onGround = $in->getBool();
 		$this->tick = $in->getUnsignedVarLong();
@@ -87,6 +92,7 @@ class CorrectPlayerMovePredictionPacket extends DataPacket implements Clientboun
 
 			$out->putFloat($this->vehicleRotation->getX());
 			$out->putFloat($this->vehicleRotation->getY());
+			$out->writeOptional($this->vehicleAngularVelocity, $out->putFloat(...));
 		}
 		$out->putBool($this->onGround);
 		$out->putUnsignedVarLong($this->tick);

--- a/src/ServerboundLoadingScreenPacket.php
+++ b/src/ServerboundLoadingScreenPacket.php
@@ -15,30 +15,30 @@ declare(strict_types=1);
 namespace pocketmine\network\mcpe\protocol;
 
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
-use pocketmine\network\mcpe\protocol\types\hud\ServerboundLoadingScreenPacketType;
+use pocketmine\network\mcpe\protocol\types\hud\LoadingScreenType;
 
 class ServerboundLoadingScreenPacket extends DataPacket implements ServerboundPacket{
 	public const NETWORK_ID = ProtocolInfo::SERVERBOUND_LOADING_SCREEN_PACKET;
 
-	private ServerboundLoadingScreenPacketType $loadingScreenType;
+	private LoadingScreenType $loadingScreenType;
 	private ?int $loadingScreenId = null;
 
 	/**
 	 * @generate-create-func
 	 */
-	public static function create(ServerboundLoadingScreenPacketType $loadingScreenType, ?int $loadingScreenId) : self{
+	public static function create(LoadingScreenType $loadingScreenType, ?int $loadingScreenId) : self{
 		$result = new self;
 		$result->loadingScreenType = $loadingScreenType;
 		$result->loadingScreenId = $loadingScreenId;
 		return $result;
 	}
 
-	public function getLoadingScreenType() : ServerboundLoadingScreenPacketType{ return $this->loadingScreenType; }
+	public function getLoadingScreenType() : LoadingScreenType{ return $this->loadingScreenType; }
 
 	public function getLoadingScreenId() : ?int{ return $this->loadingScreenId; }
 
 	protected function decodePayload(PacketSerializer $in) : void{
-		$this->loadingScreenType = ServerboundLoadingScreenPacketType::fromPacket($in->getVarInt());
+		$this->loadingScreenType = LoadingScreenType::fromPacket($in->getVarInt());
 		$this->loadingScreenId = $in->readOptional(fn() => $in->getLInt());
 	}
 

--- a/src/types/hud/LoadingScreenType.php
+++ b/src/types/hud/LoadingScreenType.php
@@ -16,7 +16,7 @@ namespace pocketmine\network\mcpe\protocol\types\hud;
 
 use pocketmine\network\mcpe\protocol\types\PacketIntEnumTrait;
 
-enum ServerboundLoadingScreenPacketType : int{
+enum LoadingScreenType : int{
 	use PacketIntEnumTrait;
 
 	case UNKNOWN = 0;

--- a/src/types/inventory/stackrequest/CraftRecipeAutoStackRequestAction.php
+++ b/src/types/inventory/stackrequest/CraftRecipeAutoStackRequestAction.php
@@ -34,7 +34,6 @@ final class CraftRecipeAutoStackRequestAction extends ItemStackRequestAction{
 	 */
 	final public function __construct(
 		private int $recipeId,
-		private int $repetitions2,
 		private int $repetitions,
 		private array $ingredients
 	){}
@@ -42,8 +41,6 @@ final class CraftRecipeAutoStackRequestAction extends ItemStackRequestAction{
 	public function getRecipeId() : int{ return $this->recipeId; }
 
 	public function getRepetitions() : int{ return $this->repetitions; }
-
-	public function getRepetitions2() : int{ return $this->repetitions2; }
 
 	/**
 	 * @return RecipeIngredient[]
@@ -53,19 +50,19 @@ final class CraftRecipeAutoStackRequestAction extends ItemStackRequestAction{
 
 	public static function read(PacketSerializer $in) : self{
 		$recipeId = $in->readRecipeNetId();
-		$repetitions2 = $in->getByte();
 		$repetitions = $in->getByte();
+		$in->getByte(); //repetitions property is sent twice, mojang...
 		$ingredients = [];
 		for($i = 0, $count = $in->getByte(); $i < $count; ++$i){
 			$ingredients[] = $in->getRecipeIngredient();
 		}
-		return new self($recipeId, $repetitions2, $repetitions, $ingredients);
+		return new self($recipeId, $repetitions, $ingredients);
 	}
 
 	public function write(PacketSerializer $out) : void{
 		$out->writeRecipeNetId($this->recipeId);
-		$out->putByte($this->repetitions2);
 		$out->putByte($this->repetitions);
+		$out->putByte($this->repetitions); //...
 		$out->putByte(count($this->ingredients));
 		foreach($this->ingredients as $ingredient){
 			$out->putRecipeIngredient($ingredient);

--- a/src/types/inventory/stackrequest/CraftRecipeAutoStackRequestAction.php
+++ b/src/types/inventory/stackrequest/CraftRecipeAutoStackRequestAction.php
@@ -35,12 +35,15 @@ final class CraftRecipeAutoStackRequestAction extends ItemStackRequestAction{
 	final public function __construct(
 		private int $recipeId,
 		private int $repetitions,
+		private int $repetitions2,
 		private array $ingredients
 	){}
 
 	public function getRecipeId() : int{ return $this->recipeId; }
 
 	public function getRepetitions() : int{ return $this->repetitions; }
+
+	public function getRepetitions2() : int{ return $this->repetitions2; }
 
 	/**
 	 * @return RecipeIngredient[]
@@ -51,18 +54,18 @@ final class CraftRecipeAutoStackRequestAction extends ItemStackRequestAction{
 	public static function read(PacketSerializer $in) : self{
 		$recipeId = $in->readRecipeNetId();
 		$repetitions = $in->getByte();
-		$in->getByte(); //repetitions property is sent twice, mojang...
+		$repetition2 = $in->getByte(); //repetitions property is sent twice, mojang...
 		$ingredients = [];
 		for($i = 0, $count = $in->getByte(); $i < $count; ++$i){
 			$ingredients[] = $in->getRecipeIngredient();
 		}
-		return new self($recipeId, $repetitions, $ingredients);
+		return new self($recipeId, $repetitions, $repetitions2, $ingredients);
 	}
 
 	public function write(PacketSerializer $out) : void{
 		$out->writeRecipeNetId($this->recipeId);
 		$out->putByte($this->repetitions);
-		$out->putByte($this->repetitions); //...
+		$out->putByte($this->repetition2);
 		$out->putByte(count($this->ingredients));
 		foreach($this->ingredients as $ingredient){
 			$out->putRecipeIngredient($ingredient);

--- a/src/types/inventory/stackrequest/CraftRecipeAutoStackRequestAction.php
+++ b/src/types/inventory/stackrequest/CraftRecipeAutoStackRequestAction.php
@@ -54,7 +54,7 @@ final class CraftRecipeAutoStackRequestAction extends ItemStackRequestAction{
 	public static function read(PacketSerializer $in) : self{
 		$recipeId = $in->readRecipeNetId();
 		$repetitions = $in->getByte();
-		$repetition2 = $in->getByte(); //repetitions property is sent twice, mojang...
+		$repetitions2 = $in->getByte(); //repetitions property is sent twice, mojang...
 		$ingredients = [];
 		for($i = 0, $count = $in->getByte(); $i < $count; ++$i){
 			$ingredients[] = $in->getRecipeIngredient();
@@ -65,7 +65,7 @@ final class CraftRecipeAutoStackRequestAction extends ItemStackRequestAction{
 	public function write(PacketSerializer $out) : void{
 		$out->writeRecipeNetId($this->recipeId);
 		$out->putByte($this->repetitions);
-		$out->putByte($this->repetition2);
+		$out->putByte($this->repetitions2);
 		$out->putByte(count($this->ingredients));
 		foreach($this->ingredients as $ingredient){
 			$out->putRecipeIngredient($ingredient);


### PR DESCRIPTION
- Added missing `vehicleAngularVelocity` property on `CorrectPlayerMovePredictionPacket` when `predictionType` is `VEHICLE`
- Renamed `ServerboundLoadingScreenPacketType` => `LoadingScreenType`
- Removed `repetitions2` field on `CraftRecipeAutoStackRequestAction` both repetitions fields holds the same data (yes, I tested this)