### PR TITLE
Fix: implicitly nullable parameter declarations deprecated in PHP 8.4

### DIFF
--- a/src/types/skin/SkinData.php
+++ b/src/types/skin/SkinData.php
@@ -36,7 +36,7 @@ class SkinData{
 		private string $resourcePatch,
 		private SkinImage $skinImage,
 		private array $animations = [],
-		SkinImage $capeImage = null,
+		?SkinImage $capeImage = null,
 		private string $geometryData = "",
 		private string $geometryDataEngineVersion = ProtocolInfo::MINECRAFT_VERSION_NETWORK,
 		private string $animationData = "",


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types