### PR TITLE
Create WeatherEffectPacket.php

### DIFF
--- a/src/WeatherEffectPacket.php
+++ b/src/WeatherEffectPacket.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol;
+
+use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
+
+class WeatherEffectPacket extends DataPacket implements ClientboundPacket, ServerboundPacket {
+    public const NETWORK_ID = ProtocolInfo::WEATHER_EFFECT_PACKET;
+
+    public int $weatherType;
+
+    public int $duration;
+
+    public int $intensity;
+
+    public bool $isLocalEffect;
+
+    public float $x, $y, $z;
+
+    /**
+     * @generate-create-func
+     */
+    public static function create(
+        int $weatherType,
+        int $duration,
+        int $intensity,
+        bool $isLocalEffect,
+        float $x,
+        float $y,
+        float $z
+    ) : self {
+        $result = new self;
+        $result->weatherType = $weatherType;
+        $result->duration = $duration;
+        $result->intensity = $intensity;
+        $result->isLocalEffect = $isLocalEffect;
+        $result->x = $x;
+        $result->y = $y;
+        $result->z = $z;
+        return $result;
+    }
+
+    protected function decodePayload(PacketSerializer $in) : void {
+        $this->weatherType = $in->getByte();
+        $this->duration = $in->getVarInt();
+        $this->intensity = $in->getVarInt();
+        $this->isLocalEffect = $in->getBool();
+        $this->x = $in->getFloat();
+        $this->y = $in->getFloat();
+        $this->z = $in->getFloat();
+    }
+
+    protected function encodePayload(PacketSerializer $out) : void {
+        $out->putByte($this->weatherType);
+        $out->putVarInt($this->duration);
+        $out->putVarInt($this->intensity);
+        $out->putBool($this->isLocalEffect);
+        $out->putFloat($this->x);
+        $out->putFloat($this->y);
+        $out->putFloat($this->z);
+    }
+
+    public function handle(PacketHandlerInterface $handler) : bool {
+        return $handler->handleWeatherEffect($this);
+    }
+}


### PR DESCRIPTION
The WeatherEffectPacket adds a new layer of environmental interaction to PocketMine servers by allowing you to implement and control dynamic weather effects in the game. This packet is designed to bring a more immersive experience to players by giving server owners the ability to create real-time weather changes that can affect gameplay. Whether it’s a sudden storm or a light drizzle, you can control it all, including its intensity and duration.

Main Features:
	•	Weather Type (int): Specifies the type of weather effect, such as rain, snow, thunderstorms, or even fog. You can also extend it in the future to include custom weather types.
	•	Duration (int): Set how long the weather effect lasts. You can make it short and sudden or have it last for as long as you want, adding variety to the gameplay.
	•	Intensity (int): Adjusts the strength of the weather effect. For example, a low intensity could be light rain, while a high intensity could cause a thunderstorm or blizzard, completely changing the atmosphere.
	•	Localized Effects (bool, coordinates): You can apply the weather globally or just to certain regions or players, making it possible to create localized weather events like storms in specific areas of the world.
	•	Synchronization: The packet ensures that all players see the same weather effect in real-time, keeping the experience consistent across the server without causing lag or synchronization issues.

Possible Uses:
	•	World Immersion: Bring your world to life with weather that changes based on the area, time of day, or season. Whether it’s a gentle rain or an intense storm, the effects can really enhance the atmosphere.
	•	Gameplay Events: Weather can be tied to certain events or game mechanics. Imagine a quest where you need to survive a storm or a boss fight where thunder strikes randomly, affecting visibility and strategy.
	•	Roleplay & Storytelling: For roleplaying servers, weather can add an extra layer of drama and immersion. Whether it’s a light snow to signal the start of winter or a thunderstorm as a story’s climax, weather can set the tone for in-game narratives.

Future Possibilities:
This system is flexible and can easily be expanded with more weather effects, interactions with player conditions (like wetness), and even custom visuals or sounds to really make the weather feel alive.