### PR TITLE
CameraAimAssistInstructionPacket is handled by server only

### DIFF
--- a/src/CameraAimAssistInstructionPacket.php
+++ b/src/CameraAimAssistInstructionPacket.php
@@ -17,7 +17,7 @@ namespace pocketmine\network\mcpe\protocol;
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\network\mcpe\protocol\types\camera\CameraAimAssistActionType;
 
-class CameraAimAssistInstructionPacket extends DataPacket implements ClientboundPacket{
+class CameraAimAssistInstructionPacket extends DataPacket implements ServerboundPacket{
 	public const NETWORK_ID = ProtocolInfo::CAMERA_AIM_ASSIST_INSTRUCTION_PACKET;
 
 	private string $presetId;


### PR DESCRIPTION
CameraAimAssistInstructionPacket is not handled by the client but the server.

(Although it has no effect)