### PR TITLE
fix(AuthenticationData): allow null titleId to support console clients

### DIFF
--- a/src/types/login/AuthenticationData.php
+++ b/src/types/login/AuthenticationData.php
@@ -27,7 +27,7 @@ final class AuthenticationData{
 
 	public string $sandboxId = "RETAIL"; //TODO: what are the other possible values?
 
-	public ?string $titleId = null; //TODO: find out what this is for
+	public ?string $titleId = ""; //TODO: find out what this is for
 
 	/** @required */
 	public string $XUID;

--- a/src/types/login/AuthenticationData.php
+++ b/src/types/login/AuthenticationData.php
@@ -27,7 +27,7 @@ final class AuthenticationData{
 
 	public string $sandboxId = "RETAIL"; //TODO: what are the other possible values?
 
-	public string $titleId = ""; //TODO: find out what this is for
+	public ?string $titleId = null; //TODO: find out what this is for
 
 	/** @required */
 	public string $XUID;


### PR DESCRIPTION
Console editions of Bedrock (**Switch, PlayStation, Xbox**) sometimes send titleId as null in the JWT payload, causing a fatal type error.  
This patch makes **AuthenticationData::$titleId** nullable (**?string**) to gracefully accept null values and prevent login crashes for console clients.
