### PR TITLE
Update display version to Bedrock 1.26.13

### DIFF
--- a/src/ProtocolInfo.php
+++ b/src/ProtocolInfo.php
@@ -34,9 +34,9 @@ final class ProtocolInfo{
 	/** Actual Minecraft: PE protocol version */
 	public const CURRENT_PROTOCOL = 944;
 	/** Display version shown in the server logs. This should match the version on the game's home screen. */
-	public const MINECRAFT_VERSION = 'v26.10';
+	public const MINECRAFT_VERSION = 'v26.13';
 	/** Version sent on the network for client side compatibility checks. This may differ from the display version. */
-	public const MINECRAFT_VERSION_NETWORK = '1.26.10';
+	public const MINECRAFT_VERSION_NETWORK = '1.26.13';
 
 	public const LOGIN_PACKET = 0x01;
 	public const PLAY_STATUS_PACKET = 0x02;


### PR DESCRIPTION
Protocol unchanged (still 944). Bumps only `MINECRAFT_VERSION` and `MINECRAFT_VERSION_NETWORK` to match the current retail client (Bedrock 1.26.13 hotfix, released 2026-04-06).

I read the notice at the top of ProtocolInfo.php — feel free to close if this isn't in scope.