### PR TITLE
Enhance DataStore with property-value support and update packet handling

### DIFF
--- a/src/ServerboundDataDrivenScreenClosedPacket.php
+++ b/src/ServerboundDataDrivenScreenClosedPacket.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol;
 
+use pmmp\encoding\Byte;
 use pmmp\encoding\ByteBufferReader;
 use pmmp\encoding\ByteBufferWriter;
 use pmmp\encoding\LE;
@@ -22,31 +23,31 @@ use pocketmine\network\mcpe\protocol\serializer\CommonTypes;
 class ServerboundDataDrivenScreenClosedPacket extends DataPacket implements ServerboundPacket{
 	public const NETWORK_ID = ProtocolInfo::SERVERBOUND_DATA_DRIVEN_SCREEN_CLOSED_PACKET;
 
-	private int $formId;
-	private string $closeReason;
+	private ?int $formId;
+	private int $closeReason;
 
 	/**
 	 * @generate-create-func
 	 */
-	public static function create(int $formId, string $closeReason) : self{
+	public static function create(?int $formId, int $closeReason) : self{
 		$result = new self;
 		$result->formId = $formId;
 		$result->closeReason = $closeReason;
 		return $result;
 	}
 
-	public function getFormId() : int{ return $this->formId; }
+	public function getFormId() : ?int{ return $this->formId; }
 
-	public function getCloseReason() : string{ return $this->closeReason; }
+	public function getCloseReason() : int{ return $this->closeReason; }
 
 	protected function decodePayload(ByteBufferReader $in) : void{
-		$this->formId = LE::readUnsignedInt($in);
-		$this->closeReason = CommonTypes::getString($in);
+		$this->formId = CommonTypes::readOptional($in, LE::readUnsignedInt(...));
+		$this->closeReason = Byte::readUnsigned($in);
 	}
 
 	protected function encodePayload(ByteBufferWriter $out) : void{
-		LE::writeUnsignedInt($out, $this->formId);
-		CommonTypes::putString($out, $this->closeReason);
+		CommonTypes::writeOptional($out, $this->formId, LE::writeUnsignedInt(...));
+		Byte::writeUnsigned($out, $this->closeReason);
 	}
 
 	public function handle(PacketHandlerInterface $handler) : bool{

--- a/src/types/BoolDataStorePropertyValue.php
+++ b/src/types/BoolDataStorePropertyValue.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of BedrockProtocol.
+ * Copyright (C) 2014-2022 PocketMine Team <https://github.com/pmmp/BedrockProtocol>
+ *
+ * BedrockProtocol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
+use pocketmine\network\mcpe\protocol\serializer\CommonTypes;
+
+final class BoolDataStorePropertyValue extends DataStorePropertyValue{
+	public const ID = DataStorePropertyType::BOOL;
+
+	public function __construct(
+		private readonly bool $value
+	){}
+
+	public function getValue() : bool{ return $this->value; }
+
+	public function getTypeId() : int{
+		return self::ID;
+	}
+
+	public function write(ByteBufferWriter $out) : void{
+		CommonTypes::putBool($out, $this->value);
+	}
+
+	public static function readPayload(ByteBufferReader $in) : self{
+		return new self(CommonTypes::getBool($in));
+	}
+}

--- a/src/types/DataStoreChange.php
+++ b/src/types/DataStoreChange.php
@@ -16,8 +16,7 @@ namespace pocketmine\network\mcpe\protocol\types;
 
 use pmmp\encoding\ByteBufferReader;
 use pmmp\encoding\ByteBufferWriter;
-use pmmp\encoding\VarInt;
-use pocketmine\network\mcpe\protocol\PacketDecodeException;
+use pmmp\encoding\LE;
 use pocketmine\network\mcpe\protocol\serializer\CommonTypes;
 
 /**
@@ -30,7 +29,7 @@ final class DataStoreChange extends DataStore {
 		private string $name,
 		private string $property,
 		private int $updateCount,
-		private DataStoreValue $data
+		private DataStorePropertyValue $newValue
 	){}
 
 	public function getTypeId() : int{
@@ -43,33 +42,27 @@ final class DataStoreChange extends DataStore {
 
 	public function getUpdateCount() : int{ return $this->updateCount; }
 
-	public function getData() : DataStoreValue{ return $this->data; }
+	public function getNewValue() : DataStorePropertyValue{ return $this->newValue; }
 
 	public static function read(ByteBufferReader $in) : self{
 		$name = CommonTypes::getString($in);
 		$property = CommonTypes::getString($in);
-		$updateCount = VarInt::readUnsignedInt($in);
+		$updateCount = LE::readUnsignedInt($in);
 
-		$data = match(VarInt::readUnsignedInt($in)){
-			DataStoreValueType::DOUBLE => DoubleDataStoreValue::read($in),
-			DataStoreValueType::BOOL => BoolDataStoreValue::read($in),
-			DataStoreValueType::STRING => StringDataStoreValue::read($in),
-			default => throw new PacketDecodeException("Unknown DataStoreValueType"),
-		};
+		$newValue = DataStorePropertyValue::read($in);
 
 		return new self(
 			$name,
 			$property,
 			$updateCount,
-			$data,
+			$newValue,
 		);
 	}
 
 	public function write(ByteBufferWriter $out) : void{
 		CommonTypes::putString($out, $this->name);
 		CommonTypes::putString($out, $this->property);
-		VarInt::writeUnsignedInt($out, $this->updateCount);
-		VarInt::writeUnsignedInt($out, $this->data->getTypeId());
-		$this->data->write($out);
+		LE::writeUnsignedInt($out, $this->updateCount);
+		$this->newValue->writeWithType($out);
 	}
 }

--- a/src/types/DataStoreMapEntry.php
+++ b/src/types/DataStoreMapEntry.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of BedrockProtocol.
+ * Copyright (C) 2014-2022 PocketMine Team <https://github.com/pmmp/BedrockProtocol>
+ *
+ * BedrockProtocol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
+use pocketmine\network\mcpe\protocol\serializer\CommonTypes;
+
+final class DataStoreMapEntry{
+
+	public function __construct(
+		private readonly string $key,
+		private readonly DataStorePropertyValue $value,
+	){}
+
+	public function getKey() : string{ return $this->key; }
+
+	public function getValue() : DataStorePropertyValue{ return $this->value; }
+
+	public static function read(ByteBufferReader $in) : self{
+		return new self(
+			CommonTypes::getString($in),
+			DataStorePropertyValue::read($in),
+		);
+	}
+
+	public function write(ByteBufferWriter $out) : void{
+		CommonTypes::putString($out, $this->key);
+		$this->value->writeWithType($out);
+	}
+}

--- a/src/types/DataStorePropertyType.php
+++ b/src/types/DataStorePropertyType.php
@@ -14,13 +14,10 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol\types;
 
-/**
- * @see ServerboundDataDrivenScreenClosedPacket
- */
-final class ScreenCloseReason{
-	public const PROGRAMMATIC_CLOSE = 0;
-	public const PROGRAMMATIC_CLOSE_ALL = 1;
-	public const CLIENT_CANCELED = 2;
-	public const USER_BUSY = 3;
-	public const INVALID_FORM = 4;
+final class DataStorePropertyType{
+	public const NONE = 0;
+	public const BOOL = 1;
+	public const INT64 = 2;
+	public const STRING = 4;
+	public const MAP = 6;
 }

--- a/src/types/DataStorePropertyValue.php
+++ b/src/types/DataStorePropertyValue.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of BedrockProtocol.
+ * Copyright (C) 2014-2022 PocketMine Team <https://github.com/pmmp/BedrockProtocol>
+ *
+ * BedrockProtocol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
+use pmmp\encoding\LE;
+use pocketmine\network\mcpe\protocol\PacketDecodeException;
+
+abstract class DataStorePropertyValue{
+
+	abstract public function getTypeId() : int;
+
+	final public static function read(ByteBufferReader $in) : self{
+		return match(LE::readSignedInt($in)){
+			DataStorePropertyType::NONE => NoneDataStorePropertyValue::readPayload($in),
+			DataStorePropertyType::BOOL => BoolDataStorePropertyValue::readPayload($in),
+			DataStorePropertyType::INT64 => Int64DataStorePropertyValue::readPayload($in),
+			DataStorePropertyType::STRING => StringDataStorePropertyValue::readPayload($in),
+			DataStorePropertyType::MAP => MapDataStorePropertyValue::readPayload($in),
+			default => throw new PacketDecodeException("Unknown DataStorePropertyType"),
+		};
+	}
+
+	final public function writeWithType(ByteBufferWriter $out) : void{
+		LE::writeSignedInt($out, $this->getTypeId());
+		$this->write($out);
+	}
+
+	abstract public function write(ByteBufferWriter $out) : void;
+}

--- a/src/types/Int64DataStorePropertyValue.php
+++ b/src/types/Int64DataStorePropertyValue.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of BedrockProtocol.
+ * Copyright (C) 2014-2022 PocketMine Team <https://github.com/pmmp/BedrockProtocol>
+ *
+ * BedrockProtocol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
+use pmmp\encoding\LE;
+
+final class Int64DataStorePropertyValue extends DataStorePropertyValue{
+	public const ID = DataStorePropertyType::INT64;
+
+	public function __construct(
+		private readonly int $value
+	){}
+
+	public function getValue() : int{ return $this->value; }
+
+	public function getTypeId() : int{
+		return self::ID;
+	}
+
+	public function write(ByteBufferWriter $out) : void{
+		LE::writeSignedLong($out, $this->value);
+	}
+
+	public static function readPayload(ByteBufferReader $in) : self{
+		return new self(LE::readSignedLong($in));
+	}
+}

--- a/src/types/MapDataStorePropertyValue.php
+++ b/src/types/MapDataStorePropertyValue.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of BedrockProtocol.
+ * Copyright (C) 2014-2022 PocketMine Team <https://github.com/pmmp/BedrockProtocol>
+ *
+ * BedrockProtocol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
+use pmmp\encoding\VarInt;
+use function count;
+
+final class MapDataStorePropertyValue extends DataStorePropertyValue{
+	public const ID = DataStorePropertyType::MAP;
+
+	/**
+	 * @param DataStoreMapEntry[] $entries
+	 * @phpstan-param list<DataStoreMapEntry> $entries
+	 */
+	public function __construct(
+		private readonly array $entries
+	){}
+
+	/**
+	 * @return DataStoreMapEntry[]
+	 * @phpstan-return list<DataStoreMapEntry>
+	 */
+	public function getEntries() : array{ return $this->entries; }
+
+	public function getTypeId() : int{
+		return self::ID;
+	}
+
+	public function write(ByteBufferWriter $out) : void{
+		VarInt::writeUnsignedInt($out, count($this->entries));
+		foreach($this->entries as $entry){
+			$entry->write($out);
+		}
+	}
+
+	public static function readPayload(ByteBufferReader $in) : self{
+		$entries = [];
+		for($i = 0, $len = VarInt::readUnsignedInt($in); $i < $len; ++$i){
+			$entries[] = DataStoreMapEntry::read($in);
+		}
+		return new self($entries);
+	}
+}

--- a/src/types/NoneDataStorePropertyValue.php
+++ b/src/types/NoneDataStorePropertyValue.php
@@ -14,13 +14,21 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol\types;
 
-/**
- * @see ServerboundDataDrivenScreenClosedPacket
- */
-final class ScreenCloseReason{
-	public const PROGRAMMATIC_CLOSE = 0;
-	public const PROGRAMMATIC_CLOSE_ALL = 1;
-	public const CLIENT_CANCELED = 2;
-	public const USER_BUSY = 3;
-	public const INVALID_FORM = 4;
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
+
+final class NoneDataStorePropertyValue extends DataStorePropertyValue{
+	public const ID = DataStorePropertyType::NONE;
+
+	public function getTypeId() : int{
+		return self::ID;
+	}
+
+	public function write(ByteBufferWriter $out) : void{
+		// NOOP
+	}
+
+	public static function readPayload(ByteBufferReader $in) : self{
+		return new self;
+	}
 }

--- a/src/types/StringDataStorePropertyValue.php
+++ b/src/types/StringDataStorePropertyValue.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of BedrockProtocol.
+ * Copyright (C) 2014-2022 PocketMine Team <https://github.com/pmmp/BedrockProtocol>
+ *
+ * BedrockProtocol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
+use pocketmine\network\mcpe\protocol\serializer\CommonTypes;
+
+final class StringDataStorePropertyValue extends DataStorePropertyValue{
+	public const ID = DataStorePropertyType::STRING;
+
+	public function __construct(
+		private readonly string $value
+	){}
+
+	public function getValue() : string{ return $this->value; }
+
+	public function getTypeId() : int{
+		return self::ID;
+	}
+
+	public function write(ByteBufferWriter $out) : void{
+		CommonTypes::putString($out, $this->value);
+	}
+
+	public static function readPayload(ByteBufferReader $in) : self{
+		return new self(CommonTypes::getString($in));
+	}
+}


### PR DESCRIPTION
Add support for the property-value format used by DataStore change entries. DataStoreChange now reads and writes DataStorePropertyValue instead of the simpler DataStoreValue type, matching the modern Bedrock data store structure for none, bool, int64, string, and map values.

Also update ServerboundDataDrivenScreenClosedPacket to use an optional form ID and numeric close reason, and update ScreenCloseReason constants to the protocol integer values.